### PR TITLE
feat: add github workflows for tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,48 @@
+name: CI Workflow
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.24.3']
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache: true
+
+    - name: Display Go version
+      run: go version
+
+    - name: Set up golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.1
+
+    - name: Run linting
+      run: make lint
+    
+    - name: Run tests
+      run: make test
+    
+    - name: Run audit checks
+      run: make audit
+    
+    - name: Verify build
+      run: make build
+    
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.go-version }}
+        path: coverage.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ This project uses [lefthook](https://github.com/evilmartians/lefthook) for Git h
 - `make upgradeable` - Check for dependency updates
 - `make build-static` - Build static binary for containers
 
+### Testing GitHub Actions Locally
+
+You can test GitHub Actions workflows locally using [act](https://github.com/nektos/act):
+
+```sh
+act pull_request    # Simulate PR workflow
+```
+
 ## Contributing Guidelines
 
 - Feature requests and bug reports are welcome via GitHub Issues
@@ -93,6 +101,9 @@ internal/               # Core logic (private to this module)
 build/                  # Build artifacts, npm wrapper (future)
 bin/                    # Compiled binaries (git-ignored)
 dist/                   # GoReleaser output (git-ignored)
+.github/
+  ├── workflows/        # GitHub Actions CI/CD pipelines
+  └── dependabot.yml    # Automated dependency updates
 ```
 
 ## Pull Request Process
@@ -102,6 +113,16 @@ dist/                   # GoReleaser output (git-ignored)
 3. Update documentation if changing functionality
 4. Submit PR with clear description of changes and motivation
 5. Ensure CI checks pass (uses same Make targets)
+
+### CI/CD Pipeline
+
+Pull requests automatically trigger GitHub Actions workflows that run:
+- `make lint` - Code style and static analysis
+- `make test` - Unit tests with race detection and coverage
+- `make audit` - Security scanning and dependency verification
+- `make build` - Binary compilation verification
+
+Coverage reports are uploaded as artifacts for each workflow run.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aws-local-sync
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jakec-dev/aws-local-sync/badge)](https://scorecard.dev/viewer/?uri=github.com/jakec-dev/aws-local-sync)
+
 **aws-local-sync** is a high-performance CLI tool that syncs data from AWS services into your local development environment. It's designed to be **simple**, **fast**, **reliable**, and **developer-friendly**, with support for plugins, caching, and seamless workflow integration.
 
 Key features:


### PR DESCRIPTION
# Completion Report
*Completed: 2025-01-06*

## What was implemented:
- GitHub Actions CI workflow for automated testing on pull requests
- Test workflow triggers on PRs to develop and master branches
- Integration with Makefile targets (lint, test, audit, build)
- Coverage report generation and artifact upload
- Dependabot configuration for automated dependency updates
- OpenSSF Scorecard badge added to README
- Line ending normalization via .gitattributes

## Deviations from plan:
- **Single Go version (1.24.3) instead of matrix**: Due to staticcheck compatibility issues with older Go versions when project requires Go 1.24.3
- **No branch protection rules**: Requires repository settings access (not file-based)
- **No separate workflows**: Consolidated into single workflow.yml for simplicity

## Decisions made:
- Focus on latest stable Go version (1.24.3) only, appropriate for learning project
- Use golangci-lint GitHub Action instead of manual installation
- Keep workflow simple and focused on core quality checks
- Use act for local testing of GitHub workflows

## Files created/modified:
- Created: `.github/workflows/workflow.yml`
- Created: `.github/dependabot.yml`
- Created: `.gitattributes`
- Modified: `README.md` (added OpenSSF Scorecard badge)

## Next steps considerations:
- When staticcheck v0.6.0 releases with Go 1.24 support, no changes needed
- If multi-version support desired later, lower go.mod requirement to 1.22 and add version matrix
- Branch protection rules should be configured in GitHub repository settings
- Consider adding security scanning (e.g., CodeQL) once there's actual code to scan
- May want to add release workflow when project reaches v0.1.0