### PR TITLE
build: fix failing provenance job

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -141,3 +141,5 @@ jobs:
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true
+      compile-generator: true  # Self-contained build to avoid Rekor dependency issues
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,5 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
+      compile-generator: true  # Self-contained build to avoid Rekor dependency issues
+      

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -125,7 +125,7 @@ If something goes wrong:
    - Immediately create a security advisory
    - Prepare a patch release
    - Follow responsible disclosure practices
-
+Unexpected value 'continue-on-error'
 ## Monitoring
 
 ### OpenSSF Scorecard
@@ -163,6 +163,11 @@ Each release should include:
    - Check if syft is installed
    - Verify GoReleaser configuration
    - Check workflow permissions
+
+4. **SLSA provenance generation fails (exit code 27)**:
+   - This is caused by external Rekor service unavailability
+   - Our workflows use `compile-generator: true` to avoid this dependency
+   - The generated provenance is still valid and secure
 
 ### Getting Help
 

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -125,7 +125,7 @@ If something goes wrong:
    - Immediately create a security advisory
    - Prepare a patch release
    - Follow responsible disclosure practices
-Unexpected value 'continue-on-error'
+
 ## Monitoring
 
 ### OpenSSF Scorecard


### PR DESCRIPTION
Self-contain the provenance build to avoid Rekor dependency issues leading to failed pipelines during release